### PR TITLE
multiple base forms with random assignment

### DIFF
--- a/src/ObjectProperties.cpp
+++ b/src/ObjectProperties.cpp
@@ -1,7 +1,7 @@
 #include "ObjectProperties.h"
 
-RandValueParams::RandValueParams(CHANCE_TYPE a_type, const RE::TESObjectREFR* a_ref) :
-	rng(a_type, a_ref)
+RandValueParams::RandValueParams(Chance a_chance, const RE::TESObjectREFR* a_ref) :
+	rng(a_chance, a_ref)
 {}
 
 FloatRange::FloatRange(const std::string& a_str)
@@ -139,15 +139,15 @@ bool ObjectProperties::IsValid() const
 	return location || rotation || refScale || recordFlagsSet != 0 || recordFlagsUnset != 0;
 }
 
-void ObjectProperties::SetChanceType(CHANCE_TYPE a_type)
+void ObjectProperties::SetChance(Chance a_chance)
 {
-	chanceType = a_type;
+	chance = a_chance;
 }
 
 void ObjectProperties::SetTransform(RE::TESObjectREFR* a_refr) const
 {
 	if (location || rotation || refScale) {
-		RandValueParams params(chanceType, a_refr);
+		RandValueParams params(chance, a_refr);
 		if (location) {
 			location->SetTransform(a_refr->data.location, params);
 		}

--- a/src/ObjectProperties.h
+++ b/src/ObjectProperties.h
@@ -4,7 +4,7 @@
 
 struct RandValueParams
 {
-	RandValueParams(CHANCE_TYPE a_type, const RE::TESObjectREFR* a_ref);
+	RandValueParams(Chance a_chance, const RE::TESObjectREFR* a_ref);
 
 	BOS_RNG rng{};
 	bool    clamp{ false };
@@ -72,7 +72,7 @@ public:
 
 	bool IsValid() const;
 
-	void SetChanceType(CHANCE_TYPE a_type);
+	void SetChance(Chance a_chance);
 	void SetTransform(RE::TESObjectREFR* a_refr) const;
 	void SetRecordFlags(RE::TESObjectREFR* a_refr) const;
 
@@ -80,7 +80,7 @@ private:
 	void assign_record_flags(const std::string& a_str, bool a_unsetFlag);
 
 	// members
-	CHANCE_TYPE chanceType{ CHANCE_TYPE::kRefHash };
+	Chance chance{};
 
 	std::optional<Point3Range> location{ std::nullopt };
 	std::optional<Point3Range> rotation{ std::nullopt };

--- a/src/PCH.h
+++ b/src/PCH.h
@@ -45,9 +45,12 @@ template <class K, class D>
 using Map = ankerl::unordered_dense::map<K, D>;
 template <class T>
 using Set = ankerl::unordered_dense::set<T>;
+template <class T>
+using OrderedSet = std::set<T>;
 
 using FormIDSet = Set<RE::FormID>;
 using FormIDOrSet = std::variant<RE::FormID, FormIDSet>;
+using FormIDOrderedSet = OrderedSet<RE::FormID>;
 
 template <class T>
 using FormIDMap = Map<RE::FormID, T>;

--- a/src/RNG.h
+++ b/src/RNG.h
@@ -1,33 +1,11 @@
 #pragma once
 
-struct BOS_RNG
+enum class CHANCE_TYPE
 {
-public:
-	enum class CHANCE_TYPE
-	{
-		kRandom,
-		kRefHash,
-		kLocationHash
-	};
-
-	BOS_RNG() = default;
-	BOS_RNG(CHANCE_TYPE a_type, const RE::TESObjectREFR* a_ref);
-
-	template <class T>
-	T generate(T a_min, T a_max) const
-	{
-		if (type == CHANCE_TYPE::kRandom) {
-			return SeedRNG().generate<T>(a_min, a_max);
-		}
-		return SeedRNG(seed).generate<T>(a_min, a_max);
-	}
-
-	// members
-	CHANCE_TYPE   type;
-	std::uint64_t seed;
+	kRandom,
+	kRefHash,
+	kLocationHash
 };
-
-using CHANCE_TYPE = BOS_RNG::CHANCE_TYPE;
 
 struct Chance
 {
@@ -40,4 +18,27 @@ public:
 	// members
 	CHANCE_TYPE   chanceType{ CHANCE_TYPE::kRefHash };
 	float chanceValue{ 100.0f };
+	std::uint64_t seed{ 0 };
+
+};
+
+struct BOS_RNG
+{
+public:
+	BOS_RNG() = default;
+	BOS_RNG(Chance a_chance, const RE::TESObjectREFR* a_ref);
+	BOS_RNG(Chance a_chance);
+
+	template <class T>
+	T generate(T a_min, T a_max) const
+	{
+		if (type == CHANCE_TYPE::kRandom && seed == 0) {
+			return SeedRNG().generate<T>(a_min, a_max);
+		}
+		return SeedRNG(seed).generate<T>(a_min, a_max);
+	}
+
+	// members
+	CHANCE_TYPE   type;
+	std::uint64_t seed { 0 };
 };

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -55,4 +55,21 @@ namespace util
 			return GetFormID(a_str);
 		}
 	}
+
+	FormIDOrderedSet GetFormIDOrderedSet(const std::string& a_str)
+	{
+		FormIDOrderedSet set;
+		if (a_str.contains(",")) {
+			const auto IDStrs = string::split(a_str, ",");
+			for (auto& IDStr : IDStrs) {
+				if (auto formID = GetFormID(IDStr); formID != 0) {
+					set.emplace(formID);
+				} else {
+					logger::error("\t\t\tfailed to process {} (formID not found)", IDStr);
+				}
+			}
+			return set;
+		}
+		return set;
+	}
 }

--- a/src/Util.h
+++ b/src/Util.h
@@ -13,4 +13,5 @@ namespace util
 
 	RE::FormID  GetFormID(const std::string& a_str);
 	FormIDOrSet GetSwapFormID(const std::string& a_str);
+	FormIDOrderedSet GetFormIDOrderedSet(const std::string& a_str);
 }


### PR DESCRIPTION
## What

I'd like to modify BaseObjectSwapper to accept **multiple base form IDs**. When the library encounters multiple base form IDs, the library would then **randomly** assign each base form to one of the multiple swap ids.

```
[Forms]
DoomstoneWarrior,DoomstoneMage,DoomstoneThief|DoomstoneWarrior,DoomstoneMage,DoomstoneThief
```

For example, this INI could randomly assign `DoomstoneWarrior` to `DoomstoneMage`, and then `DoomstoneMage` would be randomly assigned to one of `[DoomstoneWarrior, DoomstoneThief]`, since `DoomstoneMage` has already been assigned.

## Why

While it's true that the existing library supports enumerating each swap by hand, you'd have write out each permutation by hand if you wanted to see a different permutation on your next playthrough.
```
[Forms]
; Character Bob
; DoomstoneWarrior|DoomstoneMage
; DoomstoneMage|DoomstoneThief
; DoomstoneThief|DoomstoneWarrior

; Character Tim
; ...changing it up...
DoomstoneWarrior|DoomstoneThief
DoomstoneMage|DoomstoneWarrior
DoomstoneThief|DoomstoneMage
```

Basically, I think there's room for a swap type that randomizes swaps while also guaranteeing each swap only occurs once.

## Details

**Player Provided Seed String**: I originally wanted to seed the RNG with the current save game's PlayerID, but that doesn't work since BaseObjectSwapper runs before loading specific characters. Then I tried using the randomHash RNG, but that doesn't work well since activators seem to remember whatever their script properties were on the very first game load. Finally, refHashing makes the swapping static across multiple characters, which also didn't feel right. So I settled on accepting a user provided RNG seed like so:
```
[Forms]
DoomstoneWarrior,DoomstoneMage,DoomstoneThief|DoomstoneWarrior,DoomstoneMage,DoomstoneThief|NONE|NONE|randomseedstring
```
This means you can get a completely new set of swaps just by changing the seed string in one place.

**OrderedSet**: As I said earlier, activators go nuts if you swap them more than once on a play through. So, for that reason, I wanted the swaps to be deterministic given a specific, player-provided seed string. That means order matters. Therefore, I added an OrderedSet. If that's a deal breaker, I had a version that seemed to work using the unordered set library as well (I guess since the hashing is consistent?). It just felt kind of wrong to rely on read order from an unordered set library.

## Testing

Thank you for providing a working CI pipeline. I was able to build and test various test cases on 1.6.640. I originally had more logs for testing, but removed most of them.

While I am a developer, I'm not as experienced with C++, so please feel free to optimize or change the code as you see fit. I wont be offended :).

```
[Forms]

; seed is NONE
;DoomstoneWarrior,DoomstoneMage,DoomstoneThief,DoomstoneLady,DoomstoneApprentice,DoomstoneLover,DoomstoneSteed,DoomstoneAtronach,DoomstoneShadow,DoomstoneLord,DoomstoneRitual,DoomstoneTower,DoomstoneSerpent|DoomstoneWarrior,DoomstoneMage,DoomstoneThief,DoomstoneLady,DoomstoneApprentice,DoomstoneLover,DoomstoneSteed,DoomstoneAtronach,DoomstoneShadow,DoomstoneLord,DoomstoneRitual,DoomstoneTower,DoomstoneSerpent|NONE|NONE|NONE

; seed is empty
;DoomstoneWarrior,DoomstoneMage,DoomstoneThief,DoomstoneLady,DoomstoneApprentice,DoomstoneLover,DoomstoneSteed,DoomstoneAtronach,DoomstoneShadow,DoomstoneLord,DoomstoneRitual,DoomstoneTower,DoomstoneSerpent|DoomstoneWarrior,DoomstoneMage,DoomstoneThief,DoomstoneLady,DoomstoneApprentice,DoomstoneLover,DoomstoneSteed,DoomstoneAtronach,DoomstoneShadow,DoomstoneLord,DoomstoneRitual,DoomstoneTower,DoomstoneSerpent|NONE|NONE|

; swap set isnt a set, just one formid
;DoomstoneWarrior,DoomstoneMage,DoomstoneThief,DoomstoneLady,DoomstoneApprentice,DoomstoneLover,DoomstoneSteed,DoomstoneAtronach,DoomstoneShadow,DoomstoneLord,DoomstoneRitual,DoomstoneTower,DoomstoneSerpent|DoomstoneWarrior|NONE|NONE|randomized

; swap set is shorter than base set
;DoomstoneWarrior,DoomstoneMage,DoomstoneThief,DoomstoneLady,DoomstoneApprentice,DoomstoneLover,DoomstoneSteed,DoomstoneAtronach,DoomstoneShadow,DoomstoneLord,DoomstoneRitual,DoomstoneTower,DoomstoneSerpent|DoomstoneWarrior,DoomstoneMage|NONE|NONE|randomized

; duplicates, swap set twice as long
;DoomstoneWarrior,DoomstoneMage,DoomstoneThief,DoomstoneLady,DoomstoneApprentice,DoomstoneLover,DoomstoneSteed,DoomstoneAtronach,DoomstoneShadow,DoomstoneLord,DoomstoneRitual,DoomstoneTower,DoomstoneSerpent|DoomstoneWarrior,DoomstoneMage,DoomstoneThief,DoomstoneLady,DoomstoneApprentice,DoomstoneLover,DoomstoneSteed,DoomstoneAtronach,DoomstoneShadow,DoomstoneLord,DoomstoneRitual,DoomstoneTower,DoomstoneSerpent,DoomstoneWarrior,DoomstoneMage,DoomstoneThief,DoomstoneLady,DoomstoneApprentice,DoomstoneLover,DoomstoneSteed,DoomstoneAtronach,DoomstoneShadow,DoomstoneLord,DoomstoneRitual,DoomstoneTower,DoomstoneSerpent|NONE|NONE|randomized

; CHARACTER 1
;DoomstoneWarrior,DoomstoneMage,DoomstoneThief,DoomstoneLady,DoomstoneApprentice,DoomstoneLover,DoomstoneSteed,DoomstoneAtronach,DoomstoneShadow,DoomstoneLord,DoomstoneRitual,DoomstoneTower,DoomstoneSerpent|DoomstoneWarrior,DoomstoneMage,DoomstoneThief,DoomstoneLady,DoomstoneApprentice,DoomstoneLover,DoomstoneSteed,DoomstoneAtronach,DoomstoneShadow,DoomstoneLord,DoomstoneRitual,DoomstoneTower,DoomstoneSerpent|NONE|NONE|randomized

; CHARACTER 2
DoomstoneWarrior,DoomstoneMage,DoomstoneThief,DoomstoneLady,DoomstoneApprentice,DoomstoneLover,DoomstoneSteed,DoomstoneAtronach,DoomstoneShadow,DoomstoneLord,DoomstoneRitual,DoomstoneTower,DoomstoneSerpent|DoomstoneWarrior,DoomstoneMage,DoomstoneThief,DoomstoneLady,DoomstoneApprentice,DoomstoneLover,DoomstoneSteed,DoomstoneAtronach,DoomstoneShadow,DoomstoneLord,DoomstoneRitual,DoomstoneTower,DoomstoneSerpent|NONE|NONE|random

;[References]
;0x000E7BDD~Skyrim.esm,0x000E7BD6~Skyrim.esm,0x000E7BDC~Skyrim.esm,0x000E7BDC~Skyrim.esm,0x000DC84A~Skyrim.esm,0x000E0DC2~Skyrim.esm,0x000E0DBE~Skyrim.esm,0x000E0E1F~Skyrim.esm,0x000E0F4A~Skyrim.esm,0x000D1E9F~Skyrim.esm,0x000E0F22~Skyrim.esm,0x000D9630~Skyrim.esm,0x000E0F6F~Skyrim.esm,0x000E0F55~Skyrim.esm|DoomstoneWarrior,DoomstoneMage,DoomstoneThief,DoomstoneLady,DoomstoneApprentice,DoomstoneLover,DoomstoneSteed,DoomstoneAtronach,DoomstoneShadow,DoomstoneLord,DoomstoneRitual,DoomstoneTower,DoomstoneSerpent|NONE|NONE|randomized
```


