### PR TITLE
do regular swap when baseFormID1,baseFormID2|swapFormID|etc

### DIFF
--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -69,6 +69,8 @@ namespace util
 				}
 			}
 			return set;
+		} else if (auto formID = GetFormID(a_str); formID != 0) {
+			set.emplace(formID);
 		}
 		return set;
 	}


### PR DESCRIPTION
Add on to https://github.com/powerof3/BaseObjectSwapper/pull/10

After this PR the following examples should be true:

origBaseID,origBaseID2,origBaseID3|swapBaseID|propertyOverrides|chance
-> swaps all of the origBaseIDs with swapBaseID

origBaseID,origBaseID2,origBaseID3|swapBaseID,swapBaseID2,swapBaseID3|propertyOverrides|chance
-> randomly assigns each origBaseID to one of the swapBaseIDs

origBaseID,origBaseID2,origBaseID3|swapBaseID1,swapBaseID2|propertyOverrides|chance
-> logs an error. The swapBaseID set needs to either be a size of 1 or be equal/greater than the baseFormID set.

------
Test case
```
[Forms]
; swaps everything left of `|` with an AlphaTest
BleakFallsTorchlight01,BleakFallsTorchlight01NS,BleakFallsDraugrTorch01,BleakFallsDraugrTorch01NS,BleakFallsCandleLight01,BleakFallsCandleLight01NS,BleakFallsDraugrTorch01Spot,BleakFallsDraugrTorch02,BleakFallsDraugrTorch02ns,BleakFallsDraugrTorch01NS_MoveLess,BleakFallsDraugrTorch01_HalfOmni,BleakFallsCandleLight01_Flicker,BleakFallsCandleLight01NSDesat,BleakFallsCandleLight01NSDesat,BleakFallsCandleLight01NSTESTTEST,BleakFallsDraugrTorchDesat01|AlphaTest

; randomly assigns swaps for so that each item left of `|` gets one swap from the right of `|`
DoomstoneWarrior,DoomstoneMage,DoomstoneThief,DoomstoneLady,DoomstoneApprentice,DoomstoneLover,DoomstoneSteed,DoomstoneAtronach,DoomstoneShadow,DoomstoneLord,DoomstoneRitual,DoomstoneTower,DoomstoneSerpent|DoomstoneWarrior,DoomstoneMage,DoomstoneThief,DoomstoneLady,DoomstoneApprentice,DoomstoneLover,DoomstoneSteed,DoomstoneAtronach,DoomstoneShadow,DoomstoneLord,DoomstoneRitual,DoomstoneTower,DoomstoneSerpent|NONE|chanceR(100,350)

```